### PR TITLE
(SIMP-398) Eliminate all uses of lsb* facts

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,90 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
-rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+before_script:
+  - bundle
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
+  - bundle exec rake test
+notifications:
+  email: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
@@ -11,18 +11,19 @@ group :test do
   gem "rake"
   gem 'puppet', puppetversion
   gem "rspec", '< 3.2.0'
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "rspec-puppet"
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
-  gem "rspec-puppet-facts"
+  gem "simp-rspec-puppet-facts"
+
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
   # simp-rake-helpers does not suport puppet 2.7.X
-  # FIXME: simp-rake-helpers should support Puppet 4.X
-  if (!(['2','4'].include?( "#{ENV['PUPPET_VERSION']}".split('.').first)) &&
-      ("#{ENV['PUPPET_VERSION']}" !~ /~> ?(2|4)/ ? true : false) ) &&
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
       # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
       # TODO: fix upstream deps (parallel in simp-rake-helpers)
-      !( ENV['TRAVIS'] && RUBY_VERSION.sub(/\.\d+$/,'') == '1.8' )
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
     gem 'simp-rake-helpers'
   end
 end
@@ -38,6 +39,14 @@ group :development do
 end
 
 group :system_tests do
-  gem "beaker"
-  gem "beaker-rspec"
+  gem 'beaker'
+  gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,28 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
-  PuppetLint.configuration.send("disable_selector_inside_resource")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/manifests/2/conf.pp
+++ b/manifests/2/conf.pp
@@ -146,6 +146,10 @@ class freeradius::2::conf (
     }
   }
   else {
+
+    validate_net_list($rsync_server)
+    validate_integer($rsync_timeout)
+
     file { '/etc/raddb/radiusd.conf':
       ensure  => 'file',
       owner   => 'root',
@@ -167,13 +171,10 @@ class freeradius::2::conf (
       bwlimit  => $::rsync_bwlimit,
       user     => $radius_rsync_user,
       password => $radius_rsync_password ? {
-        'nil'   => passgen(['$radius_rsync_user']),
+        'nil'   => passgen("radius_rsync_${radius_rsync_user}"),
         default => $radius_rsync_password
       }
     }
-
-    validate_net_list($rsync_server)
-    validate_integer($rsync_timeout)
   }
 
   if $default_acct_listener {

--- a/manifests/3/conf/policy.pp
+++ b/manifests/3/conf/policy.pp
@@ -35,6 +35,6 @@ class freeradius::3::conf::policy {
     }
   }
   else {
-    warning("$::operatingsystem not yet supported. Current options are RedHat and CentOS")
+    warning("${::operatingsystem} not yet supported. Current options are RedHat and CentOS")
   }
 }

--- a/manifests/3/conf/sites.pp
+++ b/manifests/3/conf/sites.pp
@@ -59,7 +59,7 @@ class freeradius::3::conf::sites (
     }
   }
   else {
-    warning("$::operatingsystem not yet supported. Current options are RedHat and CentOS")
+    warning("${::operatingsystem} not yet supported. Current options are RedHat and CentOS")
   }
 
   validate_bool($enable_default)

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -23,6 +23,6 @@ class freeradius::conf {
     }
   }
   else {
-    warning("$::operatingsystem not yet supported. Current options are RedHat and CentOS")
+    warning("${::operatingsystem} not yet supported. Current options are RedHat and CentOS")
   }
 }

--- a/manifests/conf/client/add.pp
+++ b/manifests/conf/client/add.pp
@@ -40,7 +40,7 @@ define freeradius::conf::client::add (
   $coa_server = 'nil'
 ) {
 
-  file { "/etc/raddb/conf/clients/$name.conf":
+  file { "/etc/raddb/conf/clients/${name}.conf":
     owner   => 'root',
     group   => 'radiusd',
     mode    => '0640',

--- a/manifests/conf/listen/add.pp
+++ b/manifests/conf/listen/add.pp
@@ -28,7 +28,7 @@ define freeradius::conf::listen::add (
   $per_socket_clients = ''
 ) {
 
-  file { "/etc/raddb/conf/listen.inc/$name":
+  file { "/etc/raddb/conf/listen.inc/${name}":
     ensure  => 'file',
     owner   => 'root',
     group   => 'radiusd',

--- a/manifests/conf/log.pp
+++ b/manifests/conf/log.pp
@@ -26,7 +26,7 @@
 #
 class freeradius::conf::log (
   $destination = 'syslog',
-  $log_file = "$::freeradius::conf::logdir/radius.log",
+  $log_file = "${::freeradius::conf::logdir}/radius.log",
   $syslog_facility = 'local6',
   $stripped_names = false,
   $auth = true,

--- a/manifests/conf/modules.pp
+++ b/manifests/conf/modules.pp
@@ -34,6 +34,10 @@ class freeradius::conf::modules (
   $include_mysql_counter = false,
   $include_sqlippool = false
 ) {
+  validate_bool($include_eap)
+  validate_bool($include_sql)
+  validate_bool($include_mysql_counter)
+  validate_bool($include_sqlippool)
 
   include '::freeradius'
 
@@ -65,11 +69,6 @@ class freeradius::conf::modules (
     }
   }
   else {
-    warning("$::operatingsystem not yet supported. Current options are RedHat and CentOS")
+    warning("${::operatingsystem} not yet supported. Current options are RedHat and CentOS")
   }
-
-  validate_bool($include_eap)
-  validate_bool($include_sql)
-  validate_bool($include_mysql_counter)
-  validate_bool($include_sqlippool)
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@ class freeradius {
   include 'pki'
   include 'freeradius::modules'
 
-  if $::operatingsystem in ['RedHat','CentOS'] and ( versioncmp($::lsbmajdistrelease,'6') < 0 ) {
+  if $::operatingsystem in ['RedHat','CentOS'] and ( versioncmp($::operatingsystemmajrelease,'6') < 0 ) {
     $freeradius_name = 'freeradius2'
   }
   else {
@@ -76,8 +76,8 @@ class freeradius {
     enable    => true,
     hasstatus => true,
     subscribe => [
-      File["/etc/pki/private/$::fqdn.pem"],
-      File["/etc/pki/public/$::fqdn.pub"],
+      File["/etc/pki/private/${::fqdn}.pem"],
+      File["/etc/pki/public/${::fqdn}.pub"],
       File['/etc/pki/cacerts']
     ],
     require   => [

--- a/manifests/modules.pp
+++ b/manifests/modules.pp
@@ -21,6 +21,6 @@ class freeradius::modules {
     }
   }
   else {
-    warning("$::operatingsystem not yet supported. Current options are RedHat and CentOS")
+    warning("${::operatingsystem} not yet supported. Current options are RedHat and CentOS")
   }
 }

--- a/manifests/modules/ldap.pp
+++ b/manifests/modules/ldap.pp
@@ -23,6 +23,6 @@ class freeradius::modules::ldap {
     }
   }
   else {
-    warning("$::operatingsystem not yet supported. Current options are RedHat and CentOS")
+    warning("${::operatingsystem} not yet supported. Current options are RedHat and CentOS")
   }
 }

--- a/manifests/users/add.pp
+++ b/manifests/users/add.pp
@@ -65,7 +65,7 @@ define freeradius::users::add (
   $order = '100'
 ) {
 
-  file { "/etc/raddb/users.inc/$order.$name":
+  file { "/etc/raddb/users.inc/${order}.${name}":
     owner   => 'root',
     group   => 'radiusd',
     mode    => '0640',

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,45 @@
+{
+  "name":    "simp-freeradius",
+  "version": "4.2.0",
+  "author":  "simp",
+  "summary": "manages FreeRADIUS servers",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-freeradius",
+  "project_page": "https://github.com/simp/pupmod-simp-freeradius",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "freeradius" ],
+  "dependencies": [
+    {
+      "name": "simp-iptables",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-pki",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-rsync",
+      "version_requirement": ">= 4.0.1"
+    },
+    {
+      "name": "simp-simplib",
+      "version_requirement": ">= 1.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/conf/modules_spec.rb
+++ b/spec/classes/conf/modules_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'freeradius::conf::modules' do
 
   base_facts_rhel_6 = {
-    :lsbmajdistrelease  => '6',
+    :operatingsystemmajrelease  => '6',
     :operatingsystem    => 'RedHat',
     :hardwaremodel      => 'x86_64',
     :radius_version     => '2',
@@ -11,7 +11,7 @@ describe 'freeradius::conf::modules' do
     :uid_min            => '1000'
   }
   base_facts_rhel_7 = {
-    :lsbmajdistrelease  => '7',
+    :operatingsystemmajrelease  => '7',
     :operatingsystem    => 'RedHat',
     :hardwaremodel      => 'x86_64',
     :radius_version     => '3',

--- a/spec/classes/conf_spec.rb
+++ b/spec/classes/conf_spec.rb
@@ -4,7 +4,7 @@ describe 'freeradius::conf' do
 
   context 'rhel_6' do
     let(:facts) {{
-      :lsbmajdistrelease => '6',
+      :operatingsystemmajrelease => '6',
       :hardwaremodel     => 'x86_64',
       :grub_version      => '2',
       :uid_min           => '1000',
@@ -21,7 +21,7 @@ describe 'freeradius::conf' do
   context 'rhel_7' do
     let(:facts) {{
       :operatingsystem   => 'RedHat',
-      :lsbmajdistrelease => '7',
+      :operatingsystemmajrelease => '7',
       :hardwaremodel     => 'x86_64',
       :grub_version      => '2',
       :uid_min           => '1000',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'freeradius' do
   base_facts = {
-    :lsbmajdistrelease  => '6',
+    :operatingsystemmajrelease  => '6',
     :operatingsystem    => 'RedHat',
     :hardwaremodel      => 'x86_64',
     :grub_version       => '2',

--- a/spec/classes/modules/ldap_spec.rb
+++ b/spec/classes/modules/ldap_spec.rb
@@ -5,7 +5,7 @@ describe 'freeradius::modules::ldap' do
   let(:facts) {{
     :operatingsystem   => 'RedHat',
     :radius_version    => '3.0.1',
-    :lsbmajdistrelease => '7',
+    :operatingsystemmajrelease => '7',
     :hardwaremodel     => 'x86_64',
     :grub_version      => '2',
     :uid_min           => '1000'


### PR DESCRIPTION
This commit replaces all `lsb*` facts with their (package-independant)
`operatingsystem*` counterparts.  Common module assets have also been
normalized.

A bug with radius_rsync_user and passgen was noticed and corrected.

SIMP-669 #close
SIMP-398 #comment updated `pupmod-simp-freeradius`
SIMP-667 #comment updated `pupmod-simp-freeradius`
