### PR TITLE
(SIMP-1054) Update static assets to fix spec tests

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,3 +2,5 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-80chars-check
+--no-trailing_comma-check
+--no-empty_string-check

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ group :test do
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts", "~> 1.3"
 
+  gem 'puppet-lint-empty_string-check',   :require => false
+  gem 'puppet-lint-trailing_comma-check', :require => false
+
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&

--- a/manifests/conf/log.pp
+++ b/manifests/conf/log.pp
@@ -24,6 +24,7 @@
 #
 # * Trevor Vaughan <tvaughan@onyxpoint.com>
 #
+# FIXME: paramas pattern this guy
 class freeradius::conf::log (
   $destination = 'syslog',
   $log_file = "${::freeradius::logdir}/radius.log",

--- a/spec/classes/conf/log_spec.rb
+++ b/spec/classes/conf/log_spec.rb
@@ -1,7 +1,14 @@
 require 'spec_helper'
 
 describe 'freeradius::conf::log' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      let(:facts) { facts }
 
-  it { is_expected.to create_class('freeradius::conf::log') }
-  it { is_expected.to create_file('/etc/raddb/conf/log.inc') }
+      context "on #{os}" do
+        it { is_expected.to create_class('freeradius::conf::log') }
+        it { is_expected.to create_file('/etc/raddb/conf/log.inc') }
+      end
+    end
+  end
 end

--- a/spec/classes/conf_spec.rb
+++ b/spec/classes/conf_spec.rb
@@ -1,36 +1,23 @@
 require 'spec_helper'
 
 describe 'freeradius::conf' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, os_facts|
+      if ['RedHat','CentOS'].include?(os_facts[:operatingsystem]) &&
+                                      os_facts[:operatingsystemmajrelease].to_s < '7'
+        let(:facts) { os_facts.merge({ :radius_version    => '2.1.0' })}
+        let(:ver){ 'v2' }
+      else
+        let(:facts) { os_facts.merge({ :radius_version    => '3.0.1' })}
+        let(:ver){ 'v3' }
+      end
 
-  context 'rhel_6' do
-    let(:facts) {{
-      :operatingsystemmajrelease => '6',
-      :hardwaremodel     => 'x86_64',
-      :grub_version      => '2',
-      :uid_min           => '1000',
-      :operatingsystem   => 'RedHat',
-      :radius_version    => '2.1.0'
-    }}
-
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to create_class('freeradius::v2::conf') }
-    it { is_expected.to create_file('/var/log/radius').with_ensure('directory') }
-    it { is_expected.to create_file('/etc/raddb/radiusd.conf').with_content(/raddbdir/) }
-  end
-
-  context 'rhel_7' do
-    let(:facts) {{
-      :operatingsystem   => 'RedHat',
-      :operatingsystemmajrelease => '7',
-      :hardwaremodel     => 'x86_64',
-      :grub_version      => '2',
-      :uid_min           => '1000',
-      :radius_version    => '3.0.1'
-    }}
-
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to create_class('freeradius::v3::conf') }
-    it { is_expected.to create_file('/var/log/radius').with_ensure('directory') }
-    it { is_expected.to create_file('/etc/raddb/radiusd.conf').with_content(/raddbdir/) }
+      context "on #{os}" do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class("freeradius::#{ver}::conf") }
+        it { is_expected.to create_file('/var/log/freeradius').with_ensure('directory') }
+        it { is_expected.to create_file('/etc/raddb/radiusd.conf').with_content(/raddbdir/) }
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'pathname'
 require 'rspec-puppet'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'simp/rspec-puppet-facts'
+include Simp::RspecPuppetFacts
 
 # RSpec Material
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))


### PR DESCRIPTION
Before this patch, this module would fail its spec tests when
`STRICT_VARIABLES=yes` is set (as it is in Travis CI tests).
This was caused by the presence of the unset (and unused) variable
"spec_title" in the modules' fixture hieradata/hiera.yaml.

This commit fixes the issue by removing "spec_title" from
each module's hieradata/hiera.yaml.

SIMP-1054 #comment Fixed pupmod-simp-freeradius
SIMP-1075 #close Fixed spec failures when `STRICT_VARIABLES=yes`