### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,9 @@
-Requires: pupmod-simp-iptables >= 4.1.0-3
-Requires: pupmod-simp-pki >= 4.1.0-0
-Requires: pupmod-simp-openldap >= 4.1.0-3
-Requires: pupmod-simp-rsync >= 4.0.1
 Obsoletes: pupmod-freeradius-test
+Requires: pupmod-simp-iptables < 5.0.0-0
+Requires: pupmod-simp-iptables >= 4.1.4-0
+Requires: pupmod-simp-pki < 5.0.0-0
+Requires: pupmod-simp-pki >= 4.2.4-0
+Requires: pupmod-simp-rsync < 5.0.0-0
+Requires: pupmod-simp-rsync >= 4.2.2-0
+Requires: pupmod-simp-simplib < 2.0.0-0
+Requires: pupmod-simp-simplib >= 1.3.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,29 +1,32 @@
 {
-  "name":    "simp-freeradius",
-  "version": "5.0.2",
-  "author":  "simp",
-  "summary": "manages FreeRADIUS servers",
+  "name": "simp-freeradius",
+  "version": "5.0.3",
+  "author": "simp",
+  "summary": "manages FreeRADIUS authentication servers",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-freeradius",
+  "source": "https://github.com/simp/pupmod-simp-freeradius",
   "project_page": "https://github.com/simp/pupmod-simp-freeradius",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "freeradius" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "freeradius"
+  ],
   "dependencies": [
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.1.4 < 5.0.0"
     },
     {
       "name": "simp/pki",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.2.4 < 5.0.0"
     },
     {
       "name": "simp/rsync",
-      "version_requirement": ">= 4.0.1"
+      "version_requirement": ">= 4.2.2 < 5.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-freeradius`
SIMP-1610 #close