### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 8.3.0
+- Add RockyLinux 8 support
+
 * Tue Jun 15 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 8.2.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/config/rsync.pp
+++ b/manifests/config/rsync.pp
@@ -31,9 +31,9 @@
 # @param rsync_bwlimit
 #   rsync bandwidth limit
 class freeradius::config::rsync (
-  String                  $rsync_source           = "freeradius_${::environment}_${facts['os']['name']}/",
+  String                  $rsync_source           = "freeradius_${facts['environment']}_${facts['os']['name']}/",
   Simplib::Host           $rsync_server           = simplib::lookup('simp_options::rsync::server', { 'default_value' => '127.0.0.1'}),
-  String                  $radius_rsync_user      = "freeradius_systems_${::environment}_${facts['os']['name'].downcase}",
+  String                  $radius_rsync_user      = "freeradius_systems_${facts['environment']}_${facts['os']['name'].downcase}",
   String                  $radius_rsync_password  = simplib::passgen($radius_rsync_user),
   Integer                 $rsync_timeout          = simplib::lookup('simp_options::rsync::timeout', { 'default_value' => 2}),
   Optional[Integer]       $rsync_bwlimit          = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,8 +87,8 @@ class freeradius (
   Boolean                        $use_rsync               = false,
 
   Stdlib::Absolutepath           $app_pki_dir             = '/etc/pki/simp_apps/freeradius/x509',
-  Stdlib::Absolutepath           $app_pki_cert            = "${app_pki_dir}/public/${::fqdn}.pub",
-  Stdlib::Absolutepath           $app_pki_key             = "${app_pki_dir}/private/${::fqdn}.pem",
+  Stdlib::Absolutepath           $app_pki_cert            = "${app_pki_dir}/public/${facts['networking']['fqdn']}.pub",
+  Stdlib::Absolutepath           $app_pki_key             = "${app_pki_dir}/private/${facts['networking']['fqdn']}.pem",
   Stdlib::Absolutepath           $app_pki_ca              = "${app_pki_dir}/cacerts/cacerts.pem",
   Stdlib::Absolutepath           $app_pki_ca_dir          = "${app_pki_dir}/cacerts",
   Stdlib::Absolutepath           $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),

--- a/manifests/v3/conf.pp
+++ b/manifests/v3/conf.pp
@@ -162,9 +162,9 @@ class freeradius::v3::conf (
   #  the radiusd.conf file includes the file.
   if $trigger_conf_content {
     file { "${freeradius::confdir}/trigger.conf":
-      ensure => 'file',
-      content=> $trigger_conf_content,
-      *      => $file_settings,
+      ensure  => 'file',
+      content => $trigger_conf_content,
+      *       => $file_settings,
     }
   }
 

--- a/manifests/v3/listener.pp
+++ b/manifests/v3/listener.pp
@@ -41,7 +41,7 @@ define freeradius::v3::listener (
   $_target = "${confdir}/conf.d/listener.${name}"
   concat { "listener.${name}" :
       ensure => present,
-      path   => "${_target}",
+      path   => $_target,
       owner  => 'root',
       group  => $group,
       mode   => '0640',

--- a/manifests/v3/sites/ldap.pp
+++ b/manifests/v3/sites/ldap.pp
@@ -60,7 +60,7 @@ class freeradius::v3::sites::ldap (
   }
 
   if $include_listener {
-    freeradius::v3::listen { "site_ldap_auth":
+    freeradius::v3::listen { 'site_ldap_auth':
       target          => $_target,
       order           => 10,
       listen_type     => 'auth',
@@ -71,7 +71,7 @@ class freeradius::v3::sites::ldap (
       lifetime        => $lifetime
     }
 
-    freeradius::v3::listen { "site_ldap_acct":
+    freeradius::v3::listen { 'site_ldap_acct':
       target      => $_target,
       order       => 11,
       listen_type => 'acct',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-freeradius",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "author": "SIMP Team",
   "summary": "manages FreeRADIUS authentication servers",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -52,6 +52,12 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
         "8"
       ]
     }


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.